### PR TITLE
Shrink BigQuery offline store point-in-time join query

### DIFF
--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -1002,7 +1002,8 @@ SELECT {{ final_output_feature_names | backticks | join(', ')}}
 FROM entity_dataframe
 {% for featureview in featureviews %}
 LEFT JOIN (
-    SELECT * FROM {{ featureview.name }}__cleaned
+    SELECT * EXCEPT ( {{ featureview.entities | join(', ') }})
+    FROM {{ featureview.name }}__cleaned
 ) USING ({{featureview.name}}__entity_row_unique_id)
 {% endfor %}
 """

--- a/sdk/python/feast/infra/offline_stores/bigquery.py
+++ b/sdk/python/feast/infra/offline_stores/bigquery.py
@@ -1002,12 +1002,7 @@ SELECT {{ final_output_feature_names | backticks | join(', ')}}
 FROM entity_dataframe
 {% for featureview in featureviews %}
 LEFT JOIN (
-    SELECT
-        {{featureview.name}}__entity_row_unique_id
-        {% for feature in featureview.features %}
-            ,{% if full_feature_names %}{{ featureview.name }}__{{featureview.field_mapping.get(feature, feature)}}{% else %}{{ featureview.field_mapping.get(feature, feature) | backticks }}{% endif %}
-        {% endfor %}
-    FROM {{ featureview.name }}__cleaned
+    SELECT * FROM {{ featureview.name }}__cleaned
 ) USING ({{featureview.name}}__entity_row_unique_id)
 {% endfor %}
 """


### PR DESCRIPTION
Avoid enumerating all feature columns twice to make the query significantly smaller.  Verified this reduces the size by about half.