### PR TITLE
[DR-424] Remove column filter from Bigtable read

### DIFF
--- a/sdk/python/feast/infra/online_stores/bigtable.py
+++ b/sdk/python/feast/infra/online_stores/bigtable.py
@@ -3,11 +3,9 @@ import logging
 from concurrent import futures
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Set, Tuple
-import sys
 
 import google
 from google.cloud import bigtable
-from google.cloud.bigtable import row_filters
 from pydantic import StrictStr
 
 from feast import Entity, FeatureView, utils
@@ -77,22 +75,7 @@ class BigtableOnlineStore(OnlineStore):
         for row_key in row_keys:
             row_set.add_row_key(row_key)
 
-        if requested_features:
-            column_filter = row_filters.ColumnQualifierRegexFilter(
-                f"^({'|'.join(requested_features)}|event_ts)$".encode()
-            )
-        else:
-            column_filter = None
-        column_filter_size = sys.getsizeof(column_filter)
-
-        logger.info(
-            f"Reading rows for {feature_view.name} {row_keys=} {requested_features=} {column_filter_size=}"
-        )
-        rows = bt_table.read_rows(
-            row_set=row_set,
-            filter_=column_filter,
-        )
-
+        rows = bt_table.read_rows(row_set=row_set)
         # The BigTable client library only returns rows for keys that are found. This
         # means that it's our responsibility to match the returned rows to the original
         # `row_keys` and make sure that we're returning a list of the same length as


### PR DESCRIPTION
Removes `ColumnQualifierRegexFilter` filtering of columns during the Bigtable feature store read. This was causing an error for features with many feature columns due to the filter being too large: `google.api_core.exceptions.InvalidArgument: 400 Row filter exceeds maximum size of 20480 bytes`

Tested that removing the filter still works for batch prediction: https://console.cloud.google.com/dataflow/jobs/us-west1/2025-08-12_06_48_19-7627300746927051741;graphView=0?project=cph-stg-cloverhealth&inv=1&invt=Ab5SzQ&pageState=(%22dfTime%22:(%22l%22:%22dfJobMaxTime%22))